### PR TITLE
fix: Existing configs not removed

### DIFF
--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -66,7 +66,7 @@
 
         - name: Debian - Remove the extra confguration files.
           file:
-            path: "{{ item }}"
+            path: "{{ item.path }}"
             state: absent
           loop: "{{ __mysql_extra_config_files.files }}"
           when: item.path != mysql_config_path


### PR DESCRIPTION
Due to a bug the existing configs installed by mariadb packages are not removed.