### PR TITLE
Alternatives module needs a link (Ansible 2.12)

### DIFF
--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -46,6 +46,7 @@
 - name: Debian - Ensure alternatives point to mysql.cnf.
   alternatives:
     name: my.cnf
+    link: "/etc/mysql/mysql.cnf"
     path: "/etc/mysql/{{ mysql_provider }}.cnf"
 
 - name: Debian - Post-installation.


### PR DESCRIPTION
Bonjour,

Je n'ai pas réussi à déployer avec le role sans cette option. Je ne sais pas quel était le comportement auparavant.

```
# apt remove --purge mysql* mariadb*
... passage du role
Erreur indiquant que le lien est introuvable
```