### PR TITLE
Guarantee module

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Restart mysql
-  service:
+  ansible.builtin.service:
     name: "{{ mysql_service }}"
     state: "{{ mysql_service_state | default('restarted') }}"
     sleep: 5

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -2,13 +2,13 @@
 - name: mysql_databases
   block:
     - name: Ensure mysql_databases is iterable.
-      assert:
+      ansible.builtin.assert:
         that: "mysql_databases is iterable"
         fail_msg: "mysql_databases must be an iterable."
         quiet: yes
 
     - name: Ensure mysql_databases is correctly defined.
-      assert:
+      ansible.builtin.assert:
         that: item.name is defined
         fail_msg: "Items in mysql_databases must have key name."
         quiet: yes
@@ -16,19 +16,19 @@
       when: mysql_databases != []
 
 - name: Ensure mysql_db_admin_password_update is a boolean.
-  assert:
+  ansible.builtin.assert:
     that: "mysql_db_admin_password_update is boolean"
     fail_msg: "mysql_db_admin_password_update must be a boolean."
     quiet: yes
 
 - name: Ensure mysql_db_admin_password is defined.
-  assert:
+  ansible.builtin.assert:
     that: "__mysql_db_admin_password is defined"
     fail_msg: "Defining mysql_db_admin_password is mandatory."
     quiet: yes
 
 - name: Ensure mysql_provider is correctly defined.
-  assert:
+  ansible.builtin.assert:
     that: "mysql_provider in __mysql_providers"
     fail_msg: "mysql_provider must be either mysql or mariadb, not {{ mysql_provider }}."
     quiet: yes
@@ -36,13 +36,13 @@
 - name: mysql_users
   block:
     - name: Ensure mysql_users is iterable.
-      assert:
+      ansible.builtin.assert:
         that: "mysql_users is iterable"
         fail_msg: "mysql_users must be an iterable."
         quiet: yes
 
     - name: Ensure mysql_users is correctly defined.
-      assert:
+      ansible.builtin.assert:
         that:
           - item.name is defined
           - item.password is defined

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 - name: Configure - Ensure datadir exists.
-  file:
+  ansible.builtin.file:
     path: "{{ mysql_datadir }}"
     state: directory
     owner: "{{ mysql_system_user }}"
@@ -8,7 +8,7 @@
     mode: 0700
 
 - name: Configure - Ensure MySQL is configured.
-  template:
+  ansible.builtin.template:
     src: my.cnf.j2
     dest: "{{ mysql_config_path }}"
     owner: "{{ __mysql_root_user }}"
@@ -17,6 +17,6 @@
   notify: Restart mysql
 
 - name: Configure - Ensure MySQL is enabled/disabled on boot.
-  service:
+  ansible.builtin.service:
     name: "{{ mysql_service }}"
     enabled: "{{ mysql_enabled_on_startup }}"

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -1,6 +1,6 @@
 ---
 - name: Databases - Ensure MySQL databases are present.
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ item.name }}"
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: "{{ __mysql_os_name }} - Ensure /etc/mysql/ exists."
-  file:
+  ansible.builtin.file:
     path: /etc/mysql
     owner: root
     group: root
@@ -8,7 +8,7 @@
     state: directory
 
 - name: "{{ __mysql_os_name }} - Ensure {{ mysql_config_path | dirname }} exists."
-  file:
+  ansible.builtin.file:
     path: "{{ mysql_config_path | dirname }}"
     owner: root
     group: root
@@ -16,7 +16,7 @@
     state: directory
 
 - name: "{{ __mysql_os_name }} - Ensure /etc/mysql/conf.d exists."
-  file:
+  ansible.builtin.file:
     path: /etc/mysql/conf.d
     owner: root
     group: root
@@ -24,7 +24,7 @@
     state: directory
 
 - name: "{{ __mysql_os_name }} - Ensure {{ mysql_config_path }} is configured."
-  template:
+  ansible.builtin.template:
     src: my.cnf.j2
     dest: "{{ mysql_config_path }}"
     owner: root
@@ -33,46 +33,46 @@
   notify: Restart mysql
 
 - name: "{{ __mysql_os_name }} - Ensure MySQL python package is installed."
-  apt:
+  ansible.builtin.apt:
     name: "{{ mysql_python_package }}"
     state: present
 
 - name: "{{ __mysql_os_name }} - Ensure MySQL packages are installed."
-  apt:
+  ansible.builtin.apt:
     name: "{{ mysql_packages }}"
     state: present
   register: mysql_install_packages
 
 - name: "{{ __mysql_os_name }} - Ensure alternatives point to mysql.cnf."
-  alternatives:
+  community.general.alternatives:
     name: my.cnf
     path: "/etc/mysql/{{ mysql_provider }}.cnf"
 
 - name: "{{ __mysql_os_name }} - Post-installation."
   block:
     - name: "{{ __mysql_os_name }} - Remove existing /root/.my.cnf."
-      file:
+      ansible.builtin.file:
         path: /root/.my.cnf
         state: absent
 
     - when: mysql_provider == "mariadb"
       block:
         - name: "{{ __mysql_os_name }} - Check if extra configuration files are present."
-          find:
+          ansible.builtin.find:
             paths:
               - /etc/mysql/conf.d/
               - /etc/mysql/mariadb.conf.d/
           register: __mysql_extra_config_files
 
         - name: "{{ __mysql_os_name }} - Remove the extra confguration files."
-          file:
+          ansible.builtin.file:
             path: "{{ item.path }}"
             state: absent
           loop: "{{ __mysql_extra_config_files.files }}"
           when: item.path != mysql_config_path
 
     - name: "{{ __mysql_os_name }} - Ensure MySQL is started."
-      service:
+      ansible.builtin.service:
         name: "{{ mysql_service }}"
         state: started
 

--- a/tasks/install-Fedora.yml
+++ b/tasks/install-Fedora.yml
@@ -2,7 +2,7 @@
 - name: Fedora - Pre-installation.
   block:
     - name: Fedora - Ensure /etc/my.cnf is configured.
-      template:
+      ansible.builtin.template:
         src: my.cnf.j2
         dest: "{{ mysql_config_path }}"
         owner: "{{ __mysql_root_user }}"
@@ -10,12 +10,12 @@
         mode: 0644
 
 - name: Fedora - Ensure MySQL python package is installed.
-  dnf:
+  ansible.builtin.dnf:
     name: "{{ mysql_python_package }}"
     state: present
 
 - name: Fedora - Ensure MySQL packages are installed.
-  dnf:
+  ansible.builtin.dnf:
     name: "{{ mysql_packages }}"
     state: present
   register: mysql_install_packages
@@ -23,18 +23,18 @@
 - name: Fedora - Post-installation.
   block:
     - name: Fedora - Ensure MySQL database is correctly initialized (mariadb).
-      command: /usr/bin/mysql_install_db
+      ansible.builtin.command: /usr/bin/mysql_install_db
       when: mysql_provider == 'mariadb'
 
     - name: Fedora - Ensure MySQL database is correctly initialized (mysql).
-      command: |
+      ansible.builtin.command: |
         mysqld --initialize-insecure \
                --user={{ mysql_system_user }} \
                --datadir={{ mysql_datadir }}
       when: mysql_provider == 'mysql'
 
     - name: Fedora - Ensure /var/lib/mysql has correct rights.
-      file:
+      ansible.builtin.file:
         path: /var/lib/mysql
         state: directory
         recurse: yes
@@ -43,7 +43,7 @@
         mode: 0700
 
     - name: Fedora - Ensure MySQL is started.
-      service:
+      ansible.builtin.service:
         name: "{{ mysql_service }}"
         state: started
 

--- a/tasks/install-OpenBSD.yml
+++ b/tasks/install-OpenBSD.yml
@@ -2,7 +2,7 @@
 - name: OpenBSD - Pre-installation.
   block:
     - name: OpenBSD - Ensure /etc/my.cnf is configured.
-      template:
+      ansible.builtin.template:
         src: my.cnf.j2
         dest: /etc/my.cnf
         owner: root
@@ -10,12 +10,12 @@
         mode: 0644
 
 - name: OpenBSD - Ensure MySQL python package is installed.
-  openbsd_pkg:
+  community.general.openbsd_pkg:
     name: "{{ mysql_python_package }}"
     state: present
 
 - name: OpenBSD - Ensure MySQL packages are installed.
-  openbsd_pkg:
+  community.general.openbsd_pkg:
     name: "{{ mysql_packages }}"
     state: present
   register: mysql_install_packages
@@ -23,10 +23,10 @@
 - name: OpenBSD - Post-installation.
   block:
     - name: OpenBSD - Ensure MySQL database is correctly initialized.
-      command: /usr/local/bin/mysql_install_db
+      ansible.builtin.command: /usr/local/bin/mysql_install_db
 
     - name: OpenBSD - Ensure /var/run/mysql has correct rights
-      file:
+      ansible.builtin.file:
         path: /var/run/mysql
         state: directory
         owner: "{{ mysql_system_user }}"
@@ -34,7 +34,7 @@
         mode: 0711
 
     - name: OpenBSD - Ensure MySQL is started.
-      service:
+      ansible.builtin.service:
         name: "{{ mysql_service }}"
         state: started
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,12 +15,12 @@
 - name: Detection of a previous installation.
   block:
     - name: Check the state of any existing /etc/mysql/my.cnf.
-      stat:
+      ansible.builtin.stat:
         path: /etc/mysql/my.cnf
       register: __my_cnf
 
     - name: Warn if /etc/mysql/my.cnf already exists.
-      fail:
+      ansible.builtin.fail:
         msg: |
           Warning: migration from previous installation detected,
           /etc/mysql/my.cnf already exists.
@@ -41,6 +41,6 @@
 - include_tasks: users.yml
 
 - name: Ensure MySQL is in the correct state.
-  service:
+  ansible.builtin.service:
     name: "{{ mysql_service }}"
     state: "{{ mysql_service_state | default('started') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,13 +32,18 @@
 - name: Execute OS-specific tasks.
   include_tasks: install-{{ ansible_distribution }}.yml
 
-- include_tasks: configure.yml
-- include_tasks: password-change.yml
+- name: Include tasks configure.
+  include_tasks: configure.yml
+- name: Include tasks password change.
+  include_tasks: password-change.yml
   when: mysql_install_packages.changed or mysql_db_admin_password_update
-- include_tasks: secure-installation.yml
+- name: Include tasks secure-installation.
+  include_tasks: secure-installation.yml
   when: mysql_install_packages.changed
-- include_tasks: databases.yml
-- include_tasks: users.yml
+- name: Include tasks databases.
+  include_tasks: databases.yml
+- name: Include tasks users.
+  include_tasks: users.yml
 
 - name: Ensure MySQL is in the correct state.
   ansible.builtin.service:

--- a/tasks/password-change.yml
+++ b/tasks/password-change.yml
@@ -1,13 +1,13 @@
 ---
 - name: Password Change - Ensure DB admin's password is defined.
-  shell: >
+  ansible.builtin.shell: >
     mysql -NBe
     "ALTER USER '{{ mysql_db_admin_user }}'@'localhost'
     IDENTIFIED BY '{{ __mysql_db_admin_password }}'; FLUSH PRIVILEGES;"
   tags: skip_ansible_lint
 
 - name: Password Change - Ensure root's my.cnf is installed.
-  template:
+  ansible.builtin.template:
     src: "root-my.cnf.j2"
     dest: "{{ __mysql_root_home }}/.my.cnf"
     owner: "{{ __mysql_root_user }}"

--- a/tasks/purge.yml
+++ b/tasks/purge.yml
@@ -13,7 +13,7 @@
   ignore_errors: yes
 
 - name: Stop MySQL.
-  service:
+  ansible.builtin.service:
     name: "{{ mysql_service }}"
     state: stopped
   ignore_errors: yes
@@ -21,18 +21,18 @@
 - name: This block should not be needed.
   block:
     - name: Uninstall MySQL.
-      package:
+      ansible.builtin.package:
         name: "{{ mysql_packages }}"
         state: absent
 
     - name: Uninstall MySQL python packages.
-      package:
+      ansible.builtin.package:
         name: "{{ mysql_python_package }}"
         state: absent
   when: ansible_distribution != "Debian"
 
 - name: Be sure Debian really removes the packages.
-  apt:
+  ansible.builtin.apt:
     name: "{{ mysql_packages + mysql_python_package }}"
     state: absent
     purge: yes
@@ -40,16 +40,16 @@
   when: ansible_distribution == "Debian"
 
 - name: Remove MySQL configuration.
-  file:
+  ansible.builtin.file:
     path: "{{ mysql_config_path }}"
     state: absent
 
 - name: Remove root MySQL configuration.
-  file:
+  ansible.builtin.file:
     path: /root/.my.cnf
     state: absent
 
 - name: Remove MySQL data.
-  file:
+  ansible.builtin.file:
     path: "{{ mysql_datadir }}"
     state: absent

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,18 +1,18 @@
 ---
 - name: Secure Installation - Ensure remote login is disabled for admin account.
-  command: 'mysql -NBe "{{ item }}"'
+  ansible.builtin.command: 'mysql -NBe "{{ item }}"'
   loop:
     - DELETE FROM mysql.user WHERE User='{{ mysql_db_admin_user }}' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
   changed_when: false
 
 - name: Secure Installation - Get list of hosts for the anonymous user.
-  command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
+  ansible.builtin.command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
   register: mysql_anonymous_hosts
   changed_when: false
   check_mode: false
 
 - name: Secure Installation - Ensure anonymous MySQL users are removed.
-  mysql_user:
+  community.mysql.mysql_user:
     name: ""
     host: "{{ item }}"
     state: absent
@@ -20,7 +20,7 @@
   loop: "{{ mysql_anonymous_hosts.stdout_lines|default([]) }}"
 
 - name: Secure Installation - Remove MySQL test database.
-  mysql_db:
+  community.mysql.mysql_db:
     name: 'test'
     state: absent
     login_unix_socket: "{{ mysql_socket }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,6 +1,6 @@
 ---
 - name: Users - Ensure MySQL users are present.
-  mysql_user:
+  community.mysql.mysql_user:
     name: "{{ item.name }}"
     host: "{{ item.host | default('localhost') }}"
     password: "{{ item.password }}"


### PR DESCRIPTION
builtin. module and module  are the same, but ansible. builtin.module will always guarantee which module you mean to reference.
- Specify the module we want to use.
- Add name to include_tasks call.